### PR TITLE
Fixing spec around part_list and score_part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 coverage/
 rdoc/
 
+.ruby-version
+.ruby-gemset
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
     rack-protection (1.5.3)
       rack
     rainbow (2.0.0)
+    rake (11.2.2)
+    rdoc (4.2.1)
     rubocop (0.34.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.2.5, < 3.0)
@@ -53,6 +55,8 @@ PLATFORMS
 DEPENDENCIES
   minitest
   musicxml!
+  rake
+  rdoc
   rubocop
   simplecov
   sinatra
@@ -60,4 +64,4 @@ DEPENDENCIES
   uglifier
 
 BUNDLED WITH
-   1.10.6
+   1.12.5

--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -54,7 +54,7 @@ module MusicXML
     end
 
     register :part_list do
-      snodes :score_part
+      pnodes :score_part
     end
 
     register :pitch do

--- a/lib/musicxml/node/score_partwise.rb
+++ b/lib/musicxml/node/score_partwise.rb
@@ -4,8 +4,8 @@ module MusicXML
     register :score_partwise do
       sattrs :movement_title
 
-      pnodes :defaults, :part_list, :part
-      snodes :identification
+      pnodes :defaults, :part
+      snodes :identification, :part_list
 
       def to_lilypond
         source = "\\version \"#{::MusicXML::LILYPOND_VERSION}\""

--- a/musicxml.gemspec
+++ b/musicxml.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
 
   s.add_development_dependency 'minitest'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rdoc'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sinatra'
   s.add_development_dependency 'sprockets'


### PR DESCRIPTION
According to the LilyPond test suite, a part list is a singular
node that contains many score parts, which you can see in their online
test suite [here](http://lilypond.org/doc/v2.18/input/regression/musicxml/collated-files#t_g41-_002e_002e_002e-multiple-parts-_0028staves_0029).

I also added some dependencies 'cause I was having a hard time getting
the tests to run, but after than I can run them with `bundle exec rake
test` and they all passed.
