### PR TITLE
Add Chord snode

### DIFF
--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -70,5 +70,8 @@ module MusicXML
       snodes :score_instrument
     end
 
+    register :chord do
+    end
+
   end
 end

--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -70,8 +70,7 @@ module MusicXML
       snodes :score_instrument
     end
 
-    register :chord do
-    end
+    register :chord
 
     register :barline do
       snodes :repeat
@@ -81,7 +80,6 @@ module MusicXML
       props :direction, :times
     end
 
-    register :dot do
-    end
+    register :dot
   end
 end

--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -78,7 +78,10 @@ module MusicXML
     end
 
     register :repeat do
-      sattrs :direction, :times
+      props :direction, :times
+    end
+
+    register :dot do
     end
 
   end

--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -73,5 +73,13 @@ module MusicXML
     register :chord do
     end
 
+    register :barline do
+      snodes :repeat
+    end
+
+    register :repeat do
+      sattrs :direction, :times
+    end
+
   end
 end

--- a/lib/musicxml/node/measure.rb
+++ b/lib/musicxml/node/measure.rb
@@ -3,7 +3,7 @@ module MusicXML
 
     register :measure do
       sattrs :sound
-      snodes :clef, :direction, :key, :time
+      snodes :clef, :direction, :key, :time, :barline
       pnodes :note
 
       def to_lilypond

--- a/lib/musicxml/node/note.rb
+++ b/lib/musicxml/node/note.rb
@@ -4,10 +4,8 @@ module MusicXML
     register :note do
       sattrs :duration, :staff, :stem, :type, :voice
 
-      pnodes :notations
+      pnodes :notations, :dot
       snodes :pitch, :chord
-
-      props :dot
 
       # convert a note to lilypond notation
       def to_lilypond

--- a/lib/musicxml/node/note.rb
+++ b/lib/musicxml/node/note.rb
@@ -5,7 +5,7 @@ module MusicXML
       sattrs :duration, :staff, :stem, :type, :voice
 
       pnodes :notations
-      snodes :pitch
+      snodes :pitch, :chord
 
       props :dot
 

--- a/lib/musicxml/node/parser.rb
+++ b/lib/musicxml/node/parser.rb
@@ -40,8 +40,9 @@ module MusicXML
         end
 
         def properties(name)
-          prop_node = node.at(symbol_to_node(name))
-          set(name, !prop_node.nil?)
+          attr = node.attributes[symbol_to_node(name)]
+          
+          set(name, attr.nil? ? "" : attr.value)
         end
 
         def set(key, value)


### PR DESCRIPTION
MusicXML defines a chord by putting an empty `<chord />` inside a `<note>` object. This registers the chord type and adds it as an `snode` of `Note`.
