### PR TITLE
Add accidentals and transpose

### DIFF
--- a/lib/musicxml/node.rb
+++ b/lib/musicxml/node.rb
@@ -23,7 +23,11 @@ module MusicXML
 
     register :attributes do
       pattrs :divisions, :staves
-      snodes :clef, :key
+      snodes :clef, :key, :transpose
+    end
+
+    register :transpose do
+      sattrs :diatonic, :chromatic, :octave
     end
 
     register :direction do

--- a/lib/musicxml/node/measure.rb
+++ b/lib/musicxml/node/measure.rb
@@ -3,7 +3,7 @@ module MusicXML
 
     register :measure do
       sattrs :sound
-      snodes :clef, :direction, :key, :time, :barline
+      snodes :clef, :direction, :key, :time, :barline, :transpose
       pnodes :note
 
       def to_lilypond

--- a/lib/musicxml/node/note.rb
+++ b/lib/musicxml/node/note.rb
@@ -2,7 +2,7 @@ module MusicXML
   module Node
 
     register :note do
-      sattrs :duration, :staff, :stem, :type, :voice
+      sattrs :duration, :staff, :stem, :type, :voice, :accidental
 
       pnodes :notations, :dot
       snodes :pitch, :chord

--- a/test/musicxml/node/note_test.rb
+++ b/test/musicxml/node/note_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class NoteTest < Minitest::Test
+  def test_accidental
+    node = fake_node
+    note = MusicXML::Node::Note.new(node)
+    assert_equal "double-sharp", note.accidental
+  end
+
+  private
+  def fake_node
+    xml = <<-XML
+    <note>
+      <pitch>
+        <step>C</step>
+        <alter>2</alter>
+        <octave>5</octave>
+      </pitch>
+      <duration>1</duration>
+      <voice>1</voice>
+      <type>quarter</type>
+      <accidental>double-sharp</accidental>
+    </note>
+    XML
+
+    Nokogiri::XML(xml)
+  end
+end


### PR DESCRIPTION
Adds a new transpose type (discovered this when debugging guitar standard notation) and adds the accidental `sattr` to `note`.

Added a test for the accidental and will get in the habit of adding tests for new features [=
